### PR TITLE
Lazy type resolution

### DIFF
--- a/Definition/Builder/SchemaBuilder.php
+++ b/Definition/Builder/SchemaBuilder.php
@@ -51,7 +51,6 @@ class SchemaBuilder
             'query' => $query,
             'mutation' => $mutation,
             'subscription' => $subscription,
-            'types' => $this->typeResolver->getSolutions()
         ];
 
         $descriptorFile = __DIR__.'/../../../../../var/cache/dev/overblog/graph-bundle/schema-descriptor.php';
@@ -59,6 +58,15 @@ class SchemaBuilder
             $descriptor = include $descriptorFile;
 
             $config['typeResolution'] = new LazyResolution($descriptor, [$this->typeResolver, 'resolve']);
+        } else {
+            $solutions = $this->typeResolver->getSolutions();
+            $config['types'] = array_map(function($type, $typeName) {
+                if (! $type) {
+                    return $this->typeResolver->resolve($typeName);
+                }
+
+                return $type;
+            }, $solutions, array_keys($solutions));
         }
 
         $schema = new Schema($config);

--- a/Definition/Builder/SchemaBuilder.php
+++ b/Definition/Builder/SchemaBuilder.php
@@ -58,20 +58,7 @@ class SchemaBuilder
         if (file_exists($descriptorFile)) {
             $descriptor = include $descriptorFile;
 
-            $config['typeResolution'] = new LazyResolution($descriptor, function($typeName) {
-                $classNames = [
-                    "Overblog\\GraphQLBundle\\__DEFINITIONS__\\{$typeName}Type",
-                    "GraphQL\\Type\\Definition\\{$typeName}Type"
-                ];
-
-                foreach ($classNames as $className) {
-                    if (class_exists($className)) {
-                        return new $className;
-                    }
-                }
-
-                return null;
-            });
+            $config['typeResolution'] = new LazyResolution($descriptor, [$this->typeResolver, 'resolve']);
         }
 
         $schema = new Schema($config);

--- a/Definition/Builder/SchemaBuilder.php
+++ b/Definition/Builder/SchemaBuilder.php
@@ -13,6 +13,7 @@ namespace Overblog\GraphQLBundle\Definition\Builder;
 
 use GraphQL\Schema;
 use GraphQL\Type\Definition\Config;
+use GraphQL\Type\LazyResolution;
 use Overblog\GraphQLBundle\Resolver\ResolverInterface;
 
 class SchemaBuilder
@@ -46,11 +47,42 @@ class SchemaBuilder
         $mutation = $this->typeResolver->resolve($mutationAlias);
         $subscription = $this->typeResolver->resolve($subscriptionAlias);
 
-        return new Schema([
+        $config = [
             'query' => $query,
             'mutation' => $mutation,
             'subscription' => $subscription,
-            'types' => $this->typeResolver->getSolutions(),
-        ]);
+            'types' => $this->typeResolver->getSolutions()
+        ];
+
+        $descriptorFile = __DIR__.'/../../../../../var/cache/dev/overblog/graph-bundle/schema-descriptor.php';
+        if (file_exists($descriptorFile)) {
+            $descriptor = include $descriptorFile;
+
+            $config['typeResolution'] = new LazyResolution($descriptor, function($typeName) {
+                $classNames = [
+                    "Overblog\\GraphQLBundle\\__DEFINITIONS__\\{$typeName}Type",
+                    "GraphQL\\Type\\Definition\\{$typeName}Type"
+                ];
+
+                foreach ($classNames as $className) {
+                    if (class_exists($className)) {
+                        return new $className;
+                    }
+                }
+
+                return null;
+            });
+        }
+
+        $schema = new Schema($config);
+
+        if (! file_exists($descriptorFile)) {
+            file_put_contents(
+                $descriptorFile,
+                "<?php\n return " . var_export($schema->getDescriptor(), true) . ';'
+            );
+        }
+
+        return $schema;
     }
 }

--- a/DependencyInjection/Compiler/TaggedServiceMappingPass.php
+++ b/DependencyInjection/Compiler/TaggedServiceMappingPass.php
@@ -40,15 +40,7 @@ abstract class TaggedServiceMappingPass implements CompilerPassInterface
         $resolverDefinition = $container->findDefinition($this->getResolverServiceID());
 
         foreach ($mapping as $name => $options) {
-            $cleanOptions = $options;
-            $solutionID = $options['id'];
-
-            $definition = $container->findDefinition($solutionID);
-            if (is_subclass_of($definition->getClass(), 'Symfony\Component\DependencyInjection\ContainerAwareInterface')) {
-                $solutionDefinition = $container->findDefinition($options['id']);
-                $solutionDefinition->addMethodCall('setContainer', [new Reference('service_container')]);
-            }
-            $resolverDefinition->addMethodCall('addSolution', [$name, new Reference($solutionID), $cleanOptions]);
+            $resolverDefinition->addMethodCall('addSolution', [$name, null, $options]);
         }
     }
 

--- a/DependencyInjection/Compiler/TypesPass.php
+++ b/DependencyInjection/Compiler/TypesPass.php
@@ -35,6 +35,31 @@ class TypesPass implements CompilerPassInterface
                 ->addTag('overblog_graphql.type', ['alias' => $name])
             ;
         }
+
+        $types = [];
+        $possibleTypes = [];
+
+        foreach ($config as $typeConf) {
+            $typeName = $typeConf['config']['name'];
+            $types[$typeName] = 1;
+            if ($typeConf['type'] != 'object') {
+                continue;
+            }
+
+            $ifaces = $typeConf['config']['interfaces'] ?? [];
+            foreach ($ifaces as $iface) {
+                if (!array_key_exists($iface, $possibleTypes)) {
+                    $possibleTypes[$iface] = [];
+                }
+                $possibleTypes[$iface][$typeName] = 1;
+            }
+        }
+
+        $container->getDefinition('overblog_graphql.schema_builder')->replaceArgument(1, [
+            'typeMap' => $types,
+            'possibleTypeMap' => $possibleTypes,
+            'version' => '1.0'
+        ]);
     }
 
     private function processConfig(array $configs)

--- a/DependencyInjection/Compiler/TypesPass.php
+++ b/DependencyInjection/Compiler/TypesPass.php
@@ -51,16 +51,20 @@ class TypesPass implements CompilerPassInterface
         foreach ($config as $typeConf) {
             $typeName = $typeConf['config']['name'];
             $types[$typeName] = 1;
-            if ($typeConf['type'] != 'object') {
-                continue;
-            }
-
-            $ifaces = $typeConf['config']['interfaces'] ?? [];
-            foreach ($ifaces as $iface) {
-                if (!array_key_exists($iface, $possibleTypes)) {
-                    $possibleTypes[$iface] = [];
+            if ($typeConf['type'] == 'object') {
+                $ifaces = $typeConf['config']['interfaces'] ?? [];
+                foreach ($ifaces as $iface) {
+                    if (!array_key_exists($iface, $possibleTypes)) {
+                        $possibleTypes[$iface] = [];
+                    }
+                    $possibleTypes[$iface][$typeName] = 1;
                 }
-                $possibleTypes[$iface][$typeName] = 1;
+            }
+            if ($typeConf['type'] == 'union') {
+                $possibleTypes[$typeName] = [];
+                foreach ($typeConf['config']['types'] as $unionMember) {
+                    $possibleTypes[$typeName][$unionMember] = 1;
+                }
             }
         }
 

--- a/DependencyInjection/Compiler/TypesPass.php
+++ b/DependencyInjection/Compiler/TypesPass.php
@@ -36,7 +36,16 @@ class TypesPass implements CompilerPassInterface
             ;
         }
 
-        $types = [];
+        $types = [
+            '__Schema' => 1,
+            '__Type' => 1,
+            '__TypeKind' => 1,
+            '__Field' => 1,
+            '__InputValue' => 1,
+            '__EnumValue' => 1,
+            '__Directive' => 1,
+            '__DirectiveLocation' => 1
+        ];
         $possibleTypes = [];
 
         foreach ($config as $typeConf) {

--- a/Generator/TypeGenerator.php
+++ b/Generator/TypeGenerator.php
@@ -17,7 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class TypeGenerator extends BaseTypeGenerator
 {
-    const USE_FOR_CLOSURES = '$container, $request, $user, $token';
+    const USE_FOR_CLOSURES = '$container';
 
     private $cacheDir;
 

--- a/Resolver/ResolverResolver.php
+++ b/Resolver/ResolverResolver.php
@@ -11,8 +11,39 @@
 
 namespace Overblog\GraphQLBundle\Resolver;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 class ResolverResolver extends AbstractProxyResolver
 {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * ResolverResolver constructor.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getSolution($name)
+    {
+        $solution = parent::getSolution($name);
+
+        if (! $solution)  {
+            $typeOptions = $this->getSolutionOptions($name);
+            if ($typeOptions and $this->container->has($typeOptions['id'])) {
+                $solution = $this->container->get($typeOptions['id']);
+            }
+        }
+
+        return $solution;
+    }
+
     protected function unresolvableMessage($alias)
     {
         return sprintf('Unknown resolver with alias "%s" (verified service tag)', $alias);

--- a/Resolver/TypeResolver.php
+++ b/Resolver/TypeResolver.php
@@ -12,6 +12,7 @@
 namespace Overblog\GraphQLBundle\Resolver;
 
 use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Introspection;
 use Overblog\GraphQLBundle\Resolver\Cache\ArrayCache;
 use Overblog\GraphQLBundle\Resolver\Cache\CacheInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -49,6 +50,11 @@ class TypeResolver extends AbstractResolver
      */
     public function resolve($alias)
     {
+        if (strpos($alias, '__') === 0) {
+            $staticName = '_'.lcfirst(substr($alias, 2));
+            return Introspection::$staticName();
+        }
+
         if (null === $alias) {
             return;
         }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -39,6 +39,7 @@ services:
         public: false
         arguments:
             - "@overblog_graphql.type_resolver"
+            - "%overblog_graphql.definition.lazy_types_descriptor%"
             - false
 
     overblog_graphql.type_resolver:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -45,6 +45,7 @@ services:
         class: Overblog\GraphQLBundle\Resolver\TypeResolver
         arguments:
             -
+            - "@service_container"
 
     overblog_graphql.resolver_resolver:
         class: Overblog\GraphQLBundle\Resolver\ResolverResolver

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -82,7 +82,6 @@ services:
             - "%overblog_graphql.default_resolver%"
         calls:
             - ["addUseStatement", ["Symfony\\Component\\DependencyInjection\\ContainerInterface"]]
-            - ["addUseStatement", ["Symfony\\Component\\Security\\Core\\Authentication\\Token\\TokenInterface"]]
             - ["setExpressionLanguage", ["@overblog_graphql.expression_language"]]
 
     overblog_graphql.event_listener.classloader_listener:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -49,6 +49,8 @@ services:
 
     overblog_graphql.resolver_resolver:
         class: Overblog\GraphQLBundle\Resolver\ResolverResolver
+        arguments:
+            - "@service_container"
 
     overblog_graphql.mutation_resolver:
         class: Overblog\GraphQLBundle\Resolver\MutationResolver

--- a/Resources/skeleton/TypeSystem.php.skeleton
+++ b/Resources/skeleton/TypeSystem.php.skeleton
@@ -6,18 +6,6 @@
 {<traits>
 <spaces>public function __construct(ContainerInterface $container)
 <spaces>{
-<spaces><spaces>$request = null;
-<spaces><spaces>$token = null;
-<spaces><spaces>$user = null;
-<spaces><spaces>if ($container->has('request_stack')) {
-<spaces><spaces><spaces>$request = $container->get('request_stack')->getCurrentRequest();
-<spaces><spaces>}
-<spaces><spaces>if ($container->has('security.token_storage')) {
-<spaces><spaces><spaces>$token = $container->get('security.token_storage')->getToken();
-<spaces><spaces><spaces>if ($token instanceof TokenInterface) {
-<spaces><spaces><spaces><spaces>$user = $token->getUser();
-<spaces><spaces><spaces>}
-<spaces><spaces>}
 
 <spaces><spaces>parent::__construct(<config>);
 <spaces>}


### PR DESCRIPTION
Completely forgot that my mods were in the overblog fork.

I quickly switched it out for using the typeresolver. Haven't tested it though.

It's now been thoroughly tested and deployed to a test instance in prod mode. Everything is identical to devel except for introspection which has a minor flaw in the sense that types implementing an interface won't be availible from search unless they're referenced directly somewhere in the schema. This is a bug with webonyx that we should fix separately.

How much faster is it? ~30ms per request in prod.

For a company.name request it's 33ms and for a larger request getting shareholdings and using more of the schema it's 30ms. If you used the entire schema it would obviously have no difference.